### PR TITLE
[FEAT] 리뷰검색 dto에 lectureId 추가 #29

### DIFF
--- a/src/main/java/umc/reviewinclass/repository/ReviewRepositoryImpl.java
+++ b/src/main/java/umc/reviewinclass/repository/ReviewRepositoryImpl.java
@@ -55,6 +55,7 @@ public class ReviewRepositoryImpl implements ReviewRepositoryCustom {
         List<ReviewSearchListResponseDTO.ReviewDTO> results = queryFactory
                 .select(Projections.constructor(ReviewSearchListResponseDTO.ReviewDTO.class,
                         review.reviewId,
+                        review.lecture.lectureId,
                         review.content,
                         review.rating,
                         review.studyPeriod.stringValue(),

--- a/src/main/java/umc/reviewinclass/service/ReviewService/ReviewQueryServiceImpl.java
+++ b/src/main/java/umc/reviewinclass/service/ReviewService/ReviewQueryServiceImpl.java
@@ -33,6 +33,7 @@ public class ReviewQueryServiceImpl implements ReviewQueryService {
     private final ReviewRepository reviewRepository;
     private final LectureRepository lectureRepository;
 
+    // 리뷰 검색
     @Override
     public Page<ReviewSearchListResponseDTO.ReviewDTO> searchReviews(
             String query, String sort, Double minRating, Double maxRating, Pageable pageable

--- a/src/main/java/umc/reviewinclass/web/dto/review/ReviewSearchListResponseDTO.java
+++ b/src/main/java/umc/reviewinclass/web/dto/review/ReviewSearchListResponseDTO.java
@@ -25,6 +25,7 @@ public class ReviewSearchListResponseDTO {
     @Builder
     public static class ReviewDTO {
         private Long id;
+        private Long lectureId;
         private String content;
         private Float rating;
         private String period;


### PR DESCRIPTION
## 📌 관련 이슈번호

<!-- Closes 키워드가 있어야 PR이 머지되었을 때 이슈가 자동으로 닫힙니다. -->

- Closes #29

## ✅ Key Changes

> 이번 PR에서 작업한 내용을 간략히 설명해주세요

1. 리뷰 검색 응답 dto에 lectureId를 추가했습니다.

## 📢 To Reviewers (Part Leader)

-

## 📸 스크린샷

<!-- 이해하기 쉽도록 스크린샷을 첨부해주세요. -->

## 🔗 참고 자료

<!-- 참고 레퍼런스를 첨부해주세요.  -->
